### PR TITLE
Use the Validate endpoint for user login and id check

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -114,21 +114,17 @@
         if (oauthToken) {
           $('#loginForm').hide();
           $('#loading').show();
-          var userIDURL = 'https://api.twitch.tv/helix/users';
+          const validateURL = 'https://id.twitch.tv/oauth2/validate';
           $.ajax({
             dataType: 'json',
-            url: userIDURL,
+            url: validateURL,
             headers: {
-              'Client-ID': clientID,
-              'Authorization': 'Bearer ' + oauthToken,
+              'Authorization': 'OAuth ' + oauthToken,
             },
             success: function(data) {
-              console.log('hehe');
-              console.log(data);
-              data = data.data[0];
-              userID = data.id;
-              username = data.login;
-              var dataString = 'oauth_token=' + oauthToken + ';username=' + username +
+              const userID = data.user_id;
+              const username = data.login;
+              const dataString = 'oauth_token=' + oauthToken + ';username=' + username +
                 ';user_id=' + userID + ';client_id=' + clientID;
               $('#credentials .data').text(dataString);
               $('#loading').hide();
@@ -136,7 +132,6 @@
               $('.data').select();
             },
             error: function(xhr, textStatus, error) {
-              console.log('asdasd');
               console.log(textStatus);
               console.log(error);
               $('#loading .error').text('Error getting user ID. Refresh and try again');


### PR DESCRIPTION
Since Helix calls won't be usable without an app access token or an oauth token, we use the id Validate api instead to fetch a users ID.