### PR TITLE
Rename the `user:edit:broadcast` scope to `channel:manage:broadcast`

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -124,7 +124,7 @@
         'channel:edit:commercial', // in case twitch upgrades things in the future (and this scope is required)
         'user:edit:follows', // for (un)following
         'clips:edit', // for clip creation
-        'user:edit:broadcast', // for creating stream markers with /marker command
+        'channel:manage:broadcast', // for creating stream markers with /marker command, and for the /settitle and /setgame commands
         'user:read:blocked_users', // for getting list of blocked users
         'user:manage:blocked_users', // for blocking/unblocking other users
       ];


### PR DESCRIPTION
See https://dev.twitch.tv/docs/authentication#scopes and
https://dev.twitch.tv/docs/api/reference#create-stream-marker for
information about the previous name etc

See changelog entry from 2021-02-26 here: https://dev.twitch.tv/docs/change-log
