### PR TITLE
Add scope for managing held AutoMod messages

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -127,6 +127,7 @@
         'channel:manage:broadcast', // for creating stream markers with /marker command, and for the /settitle and /setgame commands
         'user:read:blocked_users', // for getting list of blocked users
         'user:manage:blocked_users', // for blocking/unblocking other users
+        'moderator:manage:automod', // for managing held AutoMod messages https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages
       ];
 
       function doRedirect() {


### PR DESCRIPTION
In an upcoming release of Chatterino we will be swapping to the [new Helix endpoint](https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages) for managing (Allowing or Denying) held AutoMod messages. To accommodate this, users will need this new scope.